### PR TITLE
Corrected documentation for `iso-2022-jp-ext` (implementation unchanged)

### DIFF
--- a/modules/codecs/__init__.krk
+++ b/modules/codecs/__init__.krk
@@ -129,7 +129,7 @@ The list of codecs (not an exhaustive list of labels, nor close to one) is as fo
 |`hz-gb-2312`|HZ (Usenet Simplified Chinese) encoding|
 |`iso-2022-cn`|7-bit stateful Chinese (Simplified and Traditional)|
 |`iso-2022-jp`|7-bit stateful Japanese, web version|
-|`iso-2022-jp-ext`|7-bit stateful Japanese, preserving katakana width|
+|`iso-2022-jp-ext`|7-bit stateful Japanese, including JIS X 0212 and preserving katakana width|
 |`iso-2022-jp-1`|7-bit stateful Japanese, including JIS X 0212|
 |`iso-2022-jp-2`|7-bit stateful Multilingual (Japanese, Korean, Greek, Simplified Chinese, Western European)|
 |`iso-2022-jp-3`|7-bit stateful Japanese, including JIS X 0213 (2000 edition format)|

--- a/modules/codecs/dbextra.krk
+++ b/modules/codecs/dbextra.krk
@@ -671,7 +671,7 @@ class Iso2022JpExtIncrementalEncoder(Iso2022JpIncrementalEncoder):
     """
     IncrementalEncoder implementation for 7-bit stateful Japanese.
 
-    This differs from the ISO-2022-JP encoder in that it preserves katakana width.
+    This differs from the ISO-2022-JP-1 encoder in that it preserves katakana width.
     """
     name = "iso-2022-jp-ext"
     html5name = None


### PR DESCRIPTION
I apparently keep momentarily forgetting that `ISO-2022-JP-Ext`, as implemented both by Python and by DEC, is an extension of `ISO-2022-JP-1`, not directly an extension of `ISO-2022-JP`.&ensp;So although I'd correctly implemented it accordingly, I'd documented it somewhat misleadingly.

(Strictly speaking, DEC also includes a two-byte private use plane.&ensp;Python does not do this; accordingly, nor did I.)