### PR TITLE
Fix an oversight in the UTF-32 endian sniffing.

### DIFF
--- a/modules/codecs/dbextra.krk
+++ b/modules/codecs/dbextra.krk
@@ -871,9 +871,14 @@ class Utf32IncrementalDecoder(IncrementalDecoder):
                 else if i == 0xFFFE0000:
                     self.state = 1
                     i = None
-                else if i & 0xFF000000:
-                    # UTF-32's highest byte will never be used, so if it has a value it's obviously
-                    #   the other endian.
+                else if i & 0xFFE00000:
+                    # UTF-32's highest eleven bits will never be used, so if they have a value it's
+                    #   obviously the other endian.
+                    self.state = 1
+                    i = data[offset + 3] | (data[offset + 2] << 8) | (data[offset + 1] << 16) | (data[offset] << 24)
+                else if not i & 0xFFFF:
+                    # More likely to the the other endian than the first character in a plane (null,
+                    #   a Linear B character, two rare Chinese characters and two PUA characters).
                     self.state = 1
                     i = data[offset + 3] | (data[offset + 2] << 8) | (data[offset + 1] << 16) | (data[offset] << 24)
                 else:


### PR DESCRIPTION
I'd mentioned in file comments that I was using the heuristic of characters at the start of the plane being rare, but it transpires I hadn't actually implemented said heuristic, only having implemented the detection of the high eight bits (which can be expanded to eleven) having to be false, which does not imply it.&ensp;This adds it.

This change improves handling for UTF-32 bytes starting with code points in the form U+xxxx00 (such as Ā, U+0100) when stored without a byte-order mark, when passed to the UTF-32 codec without an explicit byte order.