### PR TITLE
Move `setlocale()` from `rline()` to the top of `main()`

### DIFF
--- a/src/kuroko.c
+++ b/src/kuroko.c
@@ -5,6 +5,7 @@
  * or executes scripts from the argument list.
  */
 #define _DEFAULT_SOURCE
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -759,6 +760,26 @@ static int compileFile(char * argv[], int flags, char * fileName) {
 	return func == NULL;
 }
 
+void initializeLocale(void) {
+	char *myLocale;
+#ifndef _WIN32
+	myLocale = setlocale(LC_ALL, "");
+	if (myLocale != NULL) {
+		struct lconv *lc = localeconv();
+		char *decimalPoint = lc->decimal_point;
+		if (decimalPoint) {
+			if (strcmp(decimalPoint, ".") != 0) {
+				myLocale = setlocale(LC_ALL, "C.UTF-8");
+			}
+		}
+	} else {
+		myLocale = setlocale(LC_ALL, "C.UTF-8");
+	}
+#else
+	myLocale = setlocale(LC_ALL, "C.UTF-8");
+#endif
+}
+
 int main(int argc, char * argv[]) {
 #ifdef _WIN32
 	SetConsoleOutputCP(65001);
@@ -770,6 +791,7 @@ int main(int argc, char * argv[]) {
 	int inspectAfter = 0;
 	int opt;
 	int maxDepth = -1;
+	initializeLocale();
 	while ((opt = getopt(argc, argv, "+:c:C:dgGim:rR:tTMSV-:")) != -1) {
 		switch (opt) {
 			case 'c':

--- a/src/vendor/rline.c
+++ b/src/vendor/rline.c
@@ -21,7 +21,6 @@
 #include <string.h>
 #include <wchar.h>
 #include <unistd.h>
-#include <locale.h>
 #include <signal.h>
 #ifndef _WIN32
 #include <termios.h>
@@ -2429,13 +2428,6 @@ static int read_line(void) {
  * Read a line of text with interactive editing.
  */
 int rline(char * buffer, int buf_size) {
-#ifndef _WIN32
-	setlocale(LC_ALL, "");
-	/* If the requested locale doesn't use . as a radix point, fall back to C to not break float parsing. */
-	if (strtod("0.5",NULL) != 0.5) setlocale(LC_ALL, "C.UTF-8");
-#else
-	setlocale(LC_ALL, "C.UTF-8");
-#endif
 	get_initial_termios();
 	set_unbuffered();
 	get_size();


### PR DESCRIPTION
Having the `setlocale()` stuff in the `rline()` function only, invites `kuroko` to behave differently in a script and in the REPL.

The path of least surprise is to initialize the locale at the top of the `main()` entry point, before arguments have been parsed and before other routines have been called.

This pull-request:

+ moves the `setlocale()` stuff from `rline()` to the `main()` function,
+ unignores the return value of `setlocale()`, and
+ fixes #47.

Disclaimer: I don't really speak C, but I have tried to match your indentation style, and the code compiles cleanly and passes all tests.
